### PR TITLE
Add mypy, codespell, and coverage reporting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,4 +19,9 @@ jobs:
           pip install pytest pytest-asyncio pytest-cov pytest-homeassistant-custom-component
       - name: Run tests
         run: |
-          pytest --cov=custom_components.dial_a_story tests/
+          pytest --cov=custom_components.dial_a_story --cov-report=xml tests/
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,8 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        args: [--ignore-words-list, "hass"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,16 @@ select = ["E", "F", "W", "I", "B", "UP", "SIM", "RUF"]
 [tool.ruff.lint.isort]
 known-first-party = ["custom_components"]
 
+[tool.mypy]
+python_version = "3.12"
+check_untyped_defs = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = "homeassistant.*"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary
- Add mypy type checking configuration in pyproject.toml
- Add codespell to pre-commit hooks
- Add coverage reporting with Codecov to test CI

Note: Dial-a-Story already has automated releases and quality_scale.yaml.

## Test plan
- [ ] CI checks pass
- [ ] HACS validation still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)