### PR TITLE
Fix release workflow for branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,24 +31,11 @@ jobs:
           new_version="${major}.${minor}.$((patch + 1))"
           echo "version=$new_version" >> "$GITHUB_OUTPUT"
 
-      - name: Update manifest.json
+      - name: Update manifest for release zip
         run: |
           jq --arg v "${{ steps.bump.outputs.version }}" '.version = $v' \
             custom_components/dial_a_story/manifest.json > tmp.json
           mv tmp.json custom_components/dial_a_story/manifest.json
-
-      - name: Commit version bump
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add custom_components/dial_a_story/manifest.json
-          git commit -m "Bump version to ${{ steps.bump.outputs.version }}"
-          git push
-
-      - name: Create and push tag
-        run: |
-          git tag "v${{ steps.bump.outputs.version }}"
-          git push origin "v${{ steps.bump.outputs.version }}"
 
       - name: Pick release name
         id: name
@@ -97,3 +84,4 @@ jobs:
           name: "v${{ steps.bump.outputs.version }} - ${{ steps.name.outputs.name }}"
           files: dial-a-story.zip
           generate_release_notes: true
+          target_commitish: ${{ github.sha }}


### PR DESCRIPTION
## Summary
- Fix release workflow that fails because branch protection prevents direct pushes to main
- Instead of committing a version bump, the workflow now updates the manifest only in the release zip artifact
- Tags and releases are still created automatically with fun release names

## Test plan
- [ ] Release workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)