### PR TITLE
Add set_story/clear_story services for queuing custom stories

### DIFF
--- a/custom_components/dial_a_story/__init__.py
+++ b/custom_components/dial_a_story/__init__.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
 from homeassistant.components import webhook
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -31,6 +32,8 @@ from .const import (
     CONF_VOICE_PREFERENCE,
     DOMAIN,
     ELEVENLABS_VOICES,
+    SERVICE_CLEAR_STORY,
+    SERVICE_SET_STORY,
     WEBHOOK_ID,
     WEBHOOK_ID_AUDIO,
 )
@@ -86,6 +89,7 @@ class DialAStoryData:
     elevenlabs_api_key: str | None
     story_length: str
     voice_preference: str
+    queued_story: str | None = None
     active_calls: dict[str, dict[str, Any]] = field(default_factory=dict)
     audio_cache: dict[str, bytes] = field(default_factory=dict)
 
@@ -142,6 +146,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: DialAStoryConfigEntry) -
         local_only=False,
     )
 
+    async def handle_set_story(call) -> None:
+        """Handle set_story service call."""
+        story_text = call.data["story"]
+        entry.runtime_data.queued_story = story_text
+        _LOGGER.info("Story queued for next call (%d chars)", len(story_text))
+
+    async def handle_clear_story(call) -> None:
+        """Handle clear_story service call."""
+        entry.runtime_data.queued_story = None
+        _LOGGER.info("Queued story cleared")
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_STORY,
+        handle_set_story,
+        schema=vol.Schema({vol.Required("story"): cv.string}),
+    )
+    hass.services.async_register(DOMAIN, SERVICE_CLEAR_STORY, handle_clear_story)
+
     _LOGGER.info("Dial-a-Story initialized successfully")
     return True
 
@@ -153,6 +176,8 @@ async def async_unload_entry(
     """Unload a Dial-a-Story config entry."""
     webhook.async_unregister(hass, WEBHOOK_ID)
     webhook.async_unregister(hass, WEBHOOK_ID_AUDIO)
+    hass.services.async_remove(DOMAIN, SERVICE_SET_STORY)
+    hass.services.async_remove(DOMAIN, SERVICE_CLEAR_STORY)
     return True
 
 
@@ -315,7 +340,13 @@ class _CallHandler:
         await self._speak_on_call(call_control_id, story, pause=500)
 
     async def _generate_story(self) -> str:
-        """Generate a story using HA ai_task service or use backup."""
+        """Return queued story if set, otherwise generate via AI or backup."""
+        if self._data.queued_story:
+            story = self._data.queued_story
+            self._data.queued_story = None
+            _LOGGER.info("Using queued story (%d chars)", len(story))
+            return story
+
         try:
             return await self._generate_story_ai_task()
         except Exception as e:

--- a/custom_components/dial_a_story/const.py
+++ b/custom_components/dial_a_story/const.py
@@ -7,6 +7,8 @@ CONF_TELNYX_API_KEY = "telnyx_api_key"
 CONF_ELEVENLABS_API_KEY = "elevenlabs_api_key"
 CONF_STORY_LENGTH = "story_length"
 CONF_VOICE_PREFERENCE = "voice_preference"
+SERVICE_SET_STORY = "set_story"
+SERVICE_CLEAR_STORY = "clear_story"
 
 # ElevenLabs voice IDs
 ELEVENLABS_VOICES = {

--- a/custom_components/dial_a_story/services.yaml
+++ b/custom_components/dial_a_story/services.yaml
@@ -1,0 +1,16 @@
+set_story:
+  name: Set story
+  description: Queue a story to be read on the next phone call. The story is consumed after one use.
+  fields:
+    story:
+      name: Story
+      description: The full text of the story to read.
+      required: true
+      example: "Once upon a time, a little bear found a cozy cave and fell fast asleep. Sweet dreams, little one!"
+      selector:
+        text:
+          multiline: true
+
+clear_story:
+  name: Clear story
+  description: Remove the queued story so the next call uses AI-generated stories instead.

--- a/tests/test_story_queue.py
+++ b/tests/test_story_queue.py
@@ -1,0 +1,89 @@
+"""Tests for Dial-a-Story story queue (set_story / clear_story services)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.dial_a_story import DialAStoryData, _CallHandler
+from custom_components.dial_a_story.const import DOMAIN
+
+
+@pytest.fixture
+def runtime_data() -> DialAStoryData:
+    """Create runtime data with defaults."""
+    return DialAStoryData(
+        telnyx_api_key="test_key",
+        elevenlabs_api_key=None,
+        story_length="medium",
+        voice_preference="female",
+    )
+
+
+async def test_generate_story_uses_queued_story(hass: HomeAssistant, runtime_data: DialAStoryData) -> None:
+    """Test that _generate_story returns queued story and clears it."""
+    runtime_data.queued_story = "My custom story about a dragon."
+
+    # Register a mock config entry so _get_runtime_data works
+    entry = AsyncMock()
+    entry.runtime_data = runtime_data
+    entry.domain = DOMAIN
+    entry.entry_id = "test_entry"
+    hass.data.setdefault("integrations", {})
+
+    with patch(
+        "custom_components.dial_a_story._get_runtime_data",
+        return_value=runtime_data,
+    ):
+        handler = _CallHandler(hass)
+        story = await handler._generate_story()
+
+    assert story == "My custom story about a dragon."
+    assert runtime_data.queued_story is None
+
+
+async def test_generate_story_falls_through_when_no_queue(
+    hass: HomeAssistant, runtime_data: DialAStoryData
+) -> None:
+    """Test that _generate_story uses AI/backup when no queued story."""
+    assert runtime_data.queued_story is None
+
+    with (
+        patch(
+            "custom_components.dial_a_story._get_runtime_data",
+            return_value=runtime_data,
+        ),
+        patch.object(
+            _CallHandler,
+            "_generate_story_ai_task",
+            return_value="AI generated story",
+        ),
+    ):
+        handler = _CallHandler(hass)
+        story = await handler._generate_story()
+
+    assert story == "AI generated story"
+
+
+async def test_queued_story_consumed_only_once(hass: HomeAssistant, runtime_data: DialAStoryData) -> None:
+    """Test that queued story is consumed after first use."""
+    runtime_data.queued_story = "One-time story."
+
+    with (
+        patch(
+            "custom_components.dial_a_story._get_runtime_data",
+            return_value=runtime_data,
+        ),
+        patch.object(
+            _CallHandler,
+            "_generate_story_ai_task",
+            return_value="AI story",
+        ),
+    ):
+        handler = _CallHandler(hass)
+
+        first = await handler._generate_story()
+        assert first == "One-time story."
+
+        second = await handler._generate_story()
+        assert second == "AI story"


### PR DESCRIPTION
Adds two HA services that let users queue a story to be read on the next phone call. The queued story is consumed after one use, then falls back to AI-generated or backup stories as before.

- dial_a_story.set_story: queue a story (text) for the next call
- dial_a_story.clear_story: remove the queued story
- services.yaml for HA developer tools UI integration
- Tests for queue consumption and fallback behavior

https://claude.ai/code/session_01Co5TV5ZuaquxqiDgLM7anT