### PR TITLE
Skip SonarCloud scan on fork PRs where secrets are unavailable

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -22,5 +22,6 @@ jobs:
         run: pytest --cov=custom_components.dial_a_story --cov-report=xml tests/
         continue-on-error: true
       - uses: SonarSource/sonarqube-scan-action@v5
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
The Sonar scan fails on fork PRs (e.g. Dependabot) because
secrets.SONAR_TOKEN is not available, causing a "Project not found"
error. Gate the scan step to only run on pushes or PRs from the
same repository.

https://claude.ai/code/session_01JQx5uSVYwhm6dc1YyM9CgJ