### PR TITLE
Skip SonarCloud scan when SONAR_TOKEN is unavailable

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   sonarcloud:
     runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -22,6 +24,4 @@ jobs:
         run: pytest --cov=custom_components.dial_a_story --cov-report=xml tests/
         continue-on-error: true
       - uses: SonarSource/sonarqube-scan-action@v5
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        if: ${{ env.SONAR_TOKEN != '' }}


### PR DESCRIPTION
## Summary
- Gate the SonarCloud scan step on `env.SONAR_TOKEN != ''` so it is skipped whenever the secret is unavailable
- Moves `SONAR_TOKEN` to a job-level env var so the `if` condition can evaluate it
- Fixes CI failures on Dependabot and fork PRs where `secrets.SONAR_TOKEN` is not provided

## Test plan
- [ ] Verify the SonarCloud workflow passes on PRs from the main repo (where the token is available)
- [ ] Verify Dependabot PRs no longer fail at the Sonar scan step
- [ ] Verify fork PRs skip the scan step gracefully

https://claude.ai/code/session_01JQx5uSVYwhm6dc1YyM9CgJ