### PR TITLE
Pre-generate story during greeting to cut post-greeting silence

### DIFF
--- a/custom_components/dial_a_story/__init__.py
+++ b/custom_components/dial_a_story/__init__.py
@@ -283,6 +283,11 @@ class _CallHandler:
 
         call_state["state"] = "answered"
 
+        # Start generating the story text in the background while greeting plays
+        call_state["story_task"] = asyncio.create_task(
+            self._generate_story()
+        )
+
         greeting = (
             "Hello! Welcome to Dial-a-Story, your magical story friend! "
             "I'm so happy you called. Let me tell you a wonderful bedtime story!"
@@ -301,8 +306,9 @@ class _CallHandler:
         current_state = call_state.get("state")
 
         if current_state == "answered":
-            call_state["state"] = "telling_story"
+            call_state["state"] = "generating_story"
             await self._tell_story(call_control_id)
+            call_state["state"] = "telling_story"
 
         elif current_state == "telling_story":
             call_state["state"] = "offering_another"
@@ -310,6 +316,9 @@ class _CallHandler:
 
         elif current_state == "offering_another":
             await self._say_goodbye(call_control_id)
+
+        elif current_state == "goodbye":
+            await self._hangup_call(call_control_id)
 
     async def handle_gather_ended(self, payload: dict[str, Any]) -> None:
         """Handle DTMF input (key press) from caller."""
@@ -357,7 +366,29 @@ class _CallHandler:
 
     async def _tell_story(self, call_control_id: str) -> None:
         """Generate and tell a bedtime story."""
-        story = await self._generate_story()
+        call_state = self._data.active_calls.get(call_control_id)
+
+        # Use pre-generated story if available, otherwise generate now
+        story_task = call_state.get("story_task") if call_state else None
+        if story_task:
+            # Play a filler message via Telnyx TTS (fast, no API latency)
+            # while we await story text and convert to audio
+            await self._telnyx_api_call(
+                f"/v2/calls/{call_control_id}/actions/speak",
+                {
+                    "payload": (
+                        "Oh, I have a great one for you tonight! "
+                        "Are you ready? Here we go!"
+                    ),
+                    "voice": self._data.voice_preference,
+                    "language": "en-US",
+                },
+            )
+            story = await story_task
+            call_state.pop("story_task", None)
+        else:
+            story = await self._generate_story()
+
         await self._speak_on_call(call_control_id, story, pause=500)
 
     async def _generate_story(self) -> str:
@@ -435,14 +466,16 @@ class _CallHandler:
 
     async def _say_goodbye(self, call_control_id: str) -> None:
         """Say goodbye and hang up."""
+        call_state = self._data.active_calls.get(call_control_id)
+        if call_state:
+            call_state["state"] = "goodbye"
+
         goodbye = (
             "Sleep tight, little one! Dial-a-Story will be here whenever "
             "you need a bedtime story. Sweet dreams!"
         )
 
         await self._speak_on_call(call_control_id, goodbye)
-        await asyncio.sleep(3)
-        await self._hangup_call(call_control_id)
 
     async def _speak_on_call(
         self,

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,5 +1,6 @@
 """Tests for Dial-a-Story webhook handlers."""
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -299,6 +300,41 @@ async def test_webhook_speak_ended_after_offering(
         await handle_webhook(hass, "dial_a_story", mock_request)
 
     mock_goodbye.assert_called_once_with("ctrl_bye")
+
+
+async def test_webhook_speak_ended_after_goodbye(
+    hass: HomeAssistant, runtime_data: DialAStoryData, mock_request
+) -> None:
+    """Test speak.ended after goodbye hangs up the call."""
+    runtime_data.active_calls["ctrl_hangup"] = {
+        "from": "+15551111111",
+        "story_count": 0,
+        "state": "goodbye",
+    }
+
+    mock_request.json.return_value = {
+        "data": {
+            "event_type": "call.speak.ended",
+            "payload": {
+                "call_control_id": "ctrl_hangup",
+            },
+        }
+    }
+
+    with (
+        patch(
+            "custom_components.dial_a_story._get_runtime_data",
+            return_value=runtime_data,
+        ),
+        patch.object(
+            _CallHandler,
+            "_hangup_call",
+            new_callable=AsyncMock,
+        ) as mock_hangup,
+    ):
+        await handle_webhook(hass, "dial_a_story", mock_request)
+
+    mock_hangup.assert_called_once_with("ctrl_hangup")
 
 
 async def test_webhook_speak_ended_unknown_call(
@@ -1117,32 +1153,30 @@ async def test_offer_another_story(
 async def test_say_goodbye(
     hass: HomeAssistant, runtime_data: DialAStoryData
 ) -> None:
-    """Test saying goodbye speaks and hangs up."""
+    """Test saying goodbye speaks and transitions to goodbye state."""
+    runtime_data.active_calls["ctrl_bye"] = {
+        "from": "+15551111111",
+        "story_count": 0,
+        "state": "offering_another",
+    }
+
     with patch(
         "custom_components.dial_a_story._get_runtime_data",
         return_value=runtime_data,
     ):
         handler = _CallHandler(hass)
 
-    with (
-        patch.object(
-            handler,
-            "_speak_on_call",
-            new_callable=AsyncMock,
-        ) as mock_speak,
-        patch.object(
-            handler,
-            "_hangup_call",
-            new_callable=AsyncMock,
-        ) as mock_hangup,
-        patch("custom_components.dial_a_story.asyncio.sleep", new_callable=AsyncMock),
-    ):
+    with patch.object(
+        handler,
+        "_speak_on_call",
+        new_callable=AsyncMock,
+    ) as mock_speak:
         await handler._say_goodbye("ctrl_bye")
 
     mock_speak.assert_called_once()
     goodbye_text = mock_speak.call_args[0][1]
     assert "Sweet dreams" in goodbye_text
-    mock_hangup.assert_called_once_with("ctrl_bye")
+    assert runtime_data.active_calls["ctrl_bye"]["state"] == "goodbye"
 
 
 async def test_hangup_call(
@@ -1192,3 +1226,53 @@ async def test_tell_story(
         await handler._tell_story("ctrl_tell")
 
     mock_speak.assert_called_once_with("ctrl_tell", "A lovely story.", pause=500)
+
+
+async def test_tell_story_uses_pregenerated_task(
+    hass: HomeAssistant, runtime_data: DialAStoryData
+) -> None:
+    """Test tell_story awaits pre-generated story task and plays a filler."""
+
+    async def _story_coro() -> str:
+        return "Pre-baked story."
+
+    story_task = asyncio.create_task(_story_coro())
+
+    runtime_data.active_calls["ctrl_pre"] = {
+        "from": "+15551111111",
+        "story_count": 0,
+        "state": "generating_story",
+        "story_task": story_task,
+    }
+
+    with patch(
+        "custom_components.dial_a_story._get_runtime_data",
+        return_value=runtime_data,
+    ):
+        handler = _CallHandler(hass)
+
+    with (
+        patch.object(
+            handler,
+            "_generate_story",
+            new_callable=AsyncMock,
+        ) as mock_generate,
+        patch.object(
+            handler,
+            "_telnyx_api_call",
+            new_callable=AsyncMock,
+        ) as mock_api,
+        patch.object(
+            handler,
+            "_speak_on_call",
+            new_callable=AsyncMock,
+        ) as mock_speak,
+    ):
+        await handler._tell_story("ctrl_pre")
+
+    mock_generate.assert_not_called()
+    mock_api.assert_called_once()
+    filler_payload = mock_api.call_args[0][1]["payload"]
+    assert "great one" in filler_payload
+    mock_speak.assert_called_once_with("ctrl_pre", "Pre-baked story.", pause=500)
+    assert "story_task" not in runtime_data.active_calls["ctrl_pre"]


### PR DESCRIPTION
## Summary
- Synced from the live Home Assistant deployment at `/config/custom_components/dial_a_story/`.
- When a call is answered, kick off `_generate_story()` as a background task so it runs in parallel with the greeting TTS.
- When it's time to tell the story, await the pre-generated task behind a short Telnyx filler ("Oh, I have a great one for you tonight! Are you ready? Here we go!") so callers hear something immediately instead of silence while ElevenLabs synthesis happens.
- Replaced the hardcoded `asyncio.sleep(3) + _hangup_call(...)` at the end of `_say_goodbye` with a proper `goodbye` state transition — the hangup now fires on the `call.speak.ended` webhook for that state, matching the rest of the state machine.

## Test plan
- [x] `pytest tests/ -q` — 72 passed (was 71; added `test_tell_story_uses_pregenerated_task` and `test_webhook_speak_ended_after_goodbye`)
- [x] `ruff check custom_components/dial_a_story/__init__.py tests/test_webhook.py`
- [x] Updated `test_say_goodbye` to assert the new state transition instead of a direct hangup
- [ ] Verify on a real Telnyx call that the filler plays and the story audio starts without the old gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Story generation now begins in the background immediately after answering calls, reducing perceived wait time.
  * Added filler audio prompt that plays while the story is being generated.

* **Bug Fixes**
  * Improved goodbye call handling with enhanced state tracking for more reliable call termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->